### PR TITLE
Add option to change Out of Stock and Backorder text

### DIFF
--- a/i18n/languages/woocommerce-customizer.pot
+++ b/i18n/languages/woocommerce-customizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Customizer 2.5.4\n"
+"Project-Id-Version: WooCommerce Customizer 2.6.0-dev.1\n"
 "Report-Msgid-Bugs-To: "
 "https://github.com/skyverge/woocommerce-customizer/issues\n"
 "POT-Creation-Date: 2014-09-05 23:18:53+00:00\n"

--- a/i18n/languages/woocommerce-customizer.pot
+++ b/i18n/languages/woocommerce-customizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Customizer 2.5.2\n"
+"Project-Id-Version: WooCommerce Customizer 2.5.3\n"
 "Report-Msgid-Bugs-To: "
 "https://github.com/skyverge/woocommerce-customizer/issues\n"
 "POT-Creation-Date: 2014-09-05 23:18:53+00:00\n"

--- a/i18n/languages/woocommerce-customizer.pot
+++ b/i18n/languages/woocommerce-customizer.pot
@@ -1,8 +1,8 @@
-# Copyright (C) 2017 SkyVerge
+# Copyright (C) 2018 SkyVerge
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Customizer 2.5.1\n"
+"Project-Id-Version: WooCommerce Customizer 2.5.2\n"
 "Report-Msgid-Bugs-To: "
 "https://github.com/skyverge/woocommerce-customizer/issues\n"
 "POT-Creation-Date: 2014-09-05 23:18:53+00:00\n"

--- a/i18n/languages/woocommerce-customizer.pot
+++ b/i18n/languages/woocommerce-customizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Customizer 2.5.3\n"
+"Project-Id-Version: WooCommerce Customizer 2.5.4\n"
 "Report-Msgid-Bugs-To: "
 "https://github.com/skyverge/woocommerce-customizer/issues\n"
 "POT-Creation-Date: 2014-09-05 23:18:53+00:00\n"

--- a/includes/class-wc-customizer-integrations.php
+++ b/includes/class-wc-customizer-integrations.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * WooCommerce Customizer
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade WooCommerce Customizer to newer
+ * versions in the future. If you wish to customize WooCommerce Customizer for your
+ * needs please refer to http://www.skyverge.com/product/woocommerce-customizer/ for more information.
+ *
+ * @package     WC-Customizer/Classes
+ * @author      SkyVerge
+ * @copyright   Copyright (c) 2013-2018, SkyVerge, Inc.
+ * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * Class WC_Customizer_Integrations.
+ *
+ * Adds integration code for other WooCommerce extensions.
+ *
+ * @since 2.6.0-dev.1
+ */
+class WC_Customizer_Integrations {
+
+
+	/**
+	 * WC_Customizer_Integrations constructor.
+	 *
+	 * @since 2.6.0-dev.1
+	 */
+	public function __construct() {
+
+		if ( WC_Customizer::is_plugin_active( 'woocommerce-product-bundles.php' ) ) {
+
+			add_filter( 'wc_customizer_settings', array( $this, 'add_bundles_settings' ) );
+			add_filter( 'woocommerce_product_add_to_cart_text', array( $this, 'customize_bundle_add_to_cart_text' ), 150, 2 );
+		}
+	}
+
+
+	/**
+	 * Adds settings when Product Bundles is active.
+	 *
+	 * @since 2.6.0-dev.1
+	 *
+	 * @param array $settings the settings array
+	 * @return array updated settings
+	 */
+	public function add_bundles_settings( $settings ) {
+
+		$new_settings = array();
+
+		foreach ( $settings as $section => $settings_group ) {
+
+			$new_settings[ $section ] = array();
+
+			foreach ( $settings_group as $setting ) {
+
+				$new_settings[ $section ][] = $setting;
+
+				if ( 'shop_loop' === $section && isset( $setting['id'] ) && 'grouped_add_to_cart_text' === $setting['id'] ) {
+
+					// insert bundle settings after the grouped product text
+					$new_settings[ $section ][] = array(
+						'id'       => 'bundle_add_to_cart_text',
+						'title'    => __( 'Bundle Product', 'woocommerce-customizer' ),
+						'desc_tip' => __( 'Changes the add to cart button text for bundle products on all loop pages', 'woocommerce-customizer' ),
+						'type'     => 'text'
+					);
+				}
+			}
+		}
+
+		return $new_settings;
+	}
+
+
+	/**
+	 * Customizes the add to cart button for bundle products.
+	 *
+	 * @since  2.6.0-dev.1
+	 *
+	 * @param string $text add to cart text
+	 * @param WC_Product $product product object
+	 * @return string modified add to cart text
+	 */
+	public function customize_bundle_add_to_cart_text( $text, $product ) {
+
+		if ( isset( wc_customizer()->filters['bundle_add_to_cart_text'] ) && $product->is_type( 'bundle' ) ) {
+
+			// bundle add to cart text
+			$text = wc_customizer()->filters['bundle_add_to_cart_text'];
+		}
+
+		return $text;
+	}
+
+
+}

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -172,13 +172,6 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 					),
 
 					array(
-						'id'       => 'bundle_add_to_cart_text',
-						'title'    => __( 'Bundle Product', 'woocommerce-customizer' ),
-						'desc_tip' => __( 'Changes the add to cart button text for bundle products on all loop pages', 'woocommerce-customizer' ),
-						'type'     => 'text'
-					),
-
-					array(
 						'id'       => 'out_of_stock_add_to_cart_text',
 						'title'    => __( 'Out of Stock Product', 'woocommerce-customizer' ),
 						'desc_tip' => __( 'Changes the add to cart button text for out of stock products on all loop pages', 'woocommerce-customizer' ),
@@ -447,6 +440,15 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 
 				),
 		);
+
+		/**
+		 * Filters the available customizer settings.
+		 *
+		 * @since 2.6.0-dev.1
+		 *
+		 * @param array $settings the plugin settings
+		 */
+		$settings = apply_filters( 'wc_customizer_settings', $settings );
 
 		$current_section = isset( $GLOBALS['current_section'] ) ? $GLOBALS['current_section'] : 'shop_loop';
 

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -300,6 +300,20 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 					),
 
 					array( 'type' => 'sectionend' ),
+
+					array(
+						'title' => __( 'Out of Stock Text', 'woocommerce-customizer' ),
+						'type'  => 'title'
+					),
+
+					array(
+						'id'       => 'single_out_of_stock_text',
+						'title'    => __( 'Out of Stock text', 'woocommerce-customizer' ),
+						'desc_tip' => __( 'Changes text for the out of stock on product pages. Default: "Out of stock"', 'woocommerce-customizer' ),
+						'type'     => 'text',
+					),
+	
+					array( 'type' => 'sectionend' ),
 				),
 
 			'checkout' =>

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -18,7 +18,7 @@
  *
  * @package     WC-Customizer/Classes
  * @author      SkyVerge
- * @copyright   Copyright (c) 2013-2017, SkyVerge, Inc.
+ * @copyright   Copyright (c) 2013-2018, SkyVerge, Inc.
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
@@ -133,7 +133,8 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 	/**
 	 * Return admin fields in proper format for outputting / saving
 	 *
-	 * @since 1.1
+	 * @since 1.1.0
+	 *
 	 * @return array
 	 */
 	public function get_settings() {

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -171,6 +171,13 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 					),
 
 					array(
+						'id'       => 'bundle_add_to_cart_text',
+						'title'    => __( 'Bundle Product', 'woocommerce-customizer' ),
+						'desc_tip' => __( 'Changes the add to cart button text for bundle products on all loop pages', 'woocommerce-customizer' ),
+						'type'     => 'text'
+					),
+
+					array(
 						'id'       => 'out_of_stock_add_to_cart_text',
 						'title'    => __( 'Out of Stock Product', 'woocommerce-customizer' ),
 						'desc_tip' => __( 'Changes the add to cart button text for out of stock products on all loop pages', 'woocommerce-customizer' ),
@@ -312,7 +319,7 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 						'desc_tip' => __( 'Changes text for the out of stock on product pages. Default: "Out of stock"', 'woocommerce-customizer' ),
 						'type'     => 'text',
 					),
-	
+
 					array( 'type' => 'sectionend' ),
 
 					array(

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -314,6 +314,20 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 					),
 	
 					array( 'type' => 'sectionend' ),
+
+					array(
+						'title' => __( 'Backorder Text', 'woocommerce-customizer' ),
+						'type'  => 'title'
+					),
+
+					array(
+						'id'       => 'single_backorder_text',
+						'title'    => __( 'Backorder text', 'woocommerce-customizer' ),
+						'desc_tip' => __( 'Changes text for the backorder on product pages. Default: "Available on backorder"', 'woocommerce-customizer' ),
+						'type'     => 'text',
+					),
+
+					array( 'type' => 'sectionend' ),
 				),
 
 			'checkout' =>

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -287,22 +287,6 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 					array( 'type' => 'sectionend' ),
 
 					array(
-						'title' => __( 'Sale Flash', 'woocommerce-customizer' ),
-						'type'  => 'title'
-					),
-
-					array(
-						'id'       => 'single_sale_flash_text',
-						'title'    => __( 'Sale badge text', 'woocommerce-customizer' ),
-						'desc_tip' => __( 'Changes text for the sale flash on product pages. Default: "Sale!"', 'woocommerce-customizer' ),
-						'type'     => 'text',
-						/* translators: Placeholders: %1$s - <code>, %2$s - </code> */
-						'desc'     => sprintf( __( 'Use %1$s{percent}%2$s to insert percent off, e.g., "{percent} off!"', 'woocommerce-customizer' ), '<code>', '</code>' ) . '<br />' . __( 'Shows "up to n%" for grouped or variable products if multiple percentages are possible.', 'woocommerce-customizer' ),
-					),
-
-					array( 'type' => 'sectionend' ),
-
-					array(
 						'title' => __( 'Out of Stock Text', 'woocommerce-customizer' ),
 						'type'  => 'title'
 					),
@@ -314,18 +298,27 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 						'type'     => 'text',
 					),
 
-					array( 'type' => 'sectionend' ),
-
-					array(
-						'title' => __( 'Backorder Text', 'woocommerce-customizer' ),
-						'type'  => 'title'
-					),
-
 					array(
 						'id'       => 'single_backorder_text',
 						'title'    => __( 'Backorder text', 'woocommerce-customizer' ),
 						'desc_tip' => __( 'Changes text for the backorder on product pages. Default: "Available on backorder"', 'woocommerce-customizer' ),
 						'type'     => 'text',
+					),
+
+					array( 'type' => 'sectionend' ),
+
+					array(
+						'title' => __( 'Sale Flash', 'woocommerce-customizer' ),
+						'type'  => 'title'
+					),
+
+					array(
+						'id'       => 'single_sale_flash_text',
+						'title'    => __( 'Sale badge text', 'woocommerce-customizer' ),
+						'desc_tip' => __( 'Changes text for the sale flash on product pages. Default: "Sale!"', 'woocommerce-customizer' ),
+						'type'     => 'text',
+						/* translators: Placeholders: %1$s - <code>, %2$s - </code> */
+						'desc'     => sprintf( __( 'Use %1$s{percent}%2$s to insert percent off, e.g., "{percent} off!"', 'woocommerce-customizer' ), '<code>', '</code>' ) . '<br />' . __( 'Shows "up to n%" for grouped or variable products if multiple percentages are possible.', 'woocommerce-customizer' ),
 					),
 
 					array( 'type' => 'sectionend' ),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-customizer",
-	"version": "2.5.1",
+	"version": "2.6.0-dev.1",
 	"author": "SkyVerge",
 	"homepage": "http://www.skyverge.com",
 	"repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors: SkyVerge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+Customizer
 Tags: woocommerce, woocommerce shop, woocommerce filters, woocommerce text
 Requires at least: 4.1
-Tested up to: 4.9.5
-WC requires at least: 2.5.5
-WC tested up to: 3.3.3
-Stable tag: 2.5.4
+Tested up to: 4.9.6
+WC requires at least: 2.6.14
+WC tested up to: 3.4.3
+Stable tag: 2.6.0-dev.1
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -16,7 +16,7 @@ Helps you customize WooCommerce without writing any code!
 
 WooCommerce includes tons of filters to let you customize button text, labels, and more, but you have to write PHP code to use them. This plugin provides a settings page where you can add your customizations and save them without needing to write any code or modify any templates, which is helpful for quick change testing.
 
-> **Requires** WooCommerce 2.5.5+
+> **Requires** WooCommerce 2.6.14+
 
 Here are some customizations you can make:
 
@@ -73,14 +73,11 @@ Of course! Please fork the [GitHub](https://github.com/skyverge/woocommerce-cust
 
 == Changelog ==
 
-= 2.5.4 =
-* Feature - Added bundle product text customization
-
-= 2.5.3 =
-* Feature - Added backorder text customization
-
-= 2.5.2 =
-* Feature - Added out of stock text customization
+= 2.6.0-dev.1 =
+* Feature - Added backorder text customization on product pages (props [@sandysaille](https://github.com/sandysaille)!)
+* Feature - Added out of stock text customization on product pages (props [@sandysaille](https://github.com/sandysaille)!)
+* Feature - Change bundle product add to cart text with WooCommerce Product Bundles (props [@sandysaille](https://github.com/sandysaille)!)
+* Misc - Requires WooCommerce 2.6.14
 
 = 2.5.1 =
 * Tweak - Hook customizations later to be more aggressive about using WC Customizer values rather than filters from other plugins or themes

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: SkyVerge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+Customizer
 Tags: woocommerce, woocommerce shop, woocommerce filters, woocommerce text
 Requires at least: 4.1
-Tested up to: 4.8.1
+Tested up to: 4.9.5
 WC requires at least: 2.5.5
-WC tested up to: 3.1.1
+WC tested up to: 3.3.3
 Stable tag: 2.5.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.1
 Tested up to: 4.9.5
 WC requires at least: 2.5.5
 WC tested up to: 3.3.3
-Stable tag: 2.5.3
+Stable tag: 2.5.4
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -72,6 +72,9 @@ Of course! Please fork the [GitHub](https://github.com/skyverge/woocommerce-cust
 1. Settings Page to start customizing!
 
 == Changelog ==
+
+= 2.5.4 =
+* Feature - Added bundle product text customization
 
 = 2.5.3 =
 * Feature - Added backorder text customization

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.1
 Tested up to: 4.8.1
 WC requires at least: 2.5.5
 WC tested up to: 3.1.1
-Stable tag: 2.5.1
+Stable tag: 2.5.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -72,6 +72,9 @@ Of course! Please fork the [GitHub](https://github.com/skyverge/woocommerce-cust
 1. Settings Page to start customizing!
 
 == Changelog ==
+
+= 2.5.2 =
+* Feature - Added out of stock text customization
 
 = 2.5.1 =
 * Tweak - Hook customizations later to be more aggressive about using WC Customizer values rather than filters from other plugins or themes

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.1
 Tested up to: 4.9.5
 WC requires at least: 2.5.5
 WC tested up to: 3.3.3
-Stable tag: 2.5.2
+Stable tag: 2.5.3
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -72,6 +72,9 @@ Of course! Please fork the [GitHub](https://github.com/skyverge/woocommerce-cust
 1. Settings Page to start customizing!
 
 == Changelog ==
+
+= 2.5.3 =
+* Feature - Added backorder text customization
 
 = 2.5.2 =
 * Feature - Added out of stock text customization

--- a/readme.txt
+++ b/readme.txt
@@ -76,7 +76,7 @@ Of course! Please fork the [GitHub](https://github.com/skyverge/woocommerce-cust
 = 2.6.0-dev.1 =
 * Feature - Added backorder text customization on product pages (props [@sandysaille](https://github.com/sandysaille)!)
 * Feature - Added out of stock text customization on product pages (props [@sandysaille](https://github.com/sandysaille)!)
-* Feature - Change bundle product add to cart text with WooCommerce Product Bundles (props [@sandysaille](https://github.com/sandysaille)!)
+* Feature - Change bundle product add to cart text with WooCommerce Product Bundles (props [@DaisukiDaYo](https://github.com/DaisukiDaYo)!)
 * Misc - Requires WooCommerce 2.6.14
 
 = 2.5.1 =

--- a/sake.config.js
+++ b/sake.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	framework: false,
+	deploy: 'wp'
+}

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -5,7 +5,7 @@
  * Description: Customize WooCommerce without code! Easily change add to cart button text and more.
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 2.5.2
+ * Version: 2.5.3
  * Text Domain: woocommerce-customizer
  * Domain Path: /i18n/languages/
  *
@@ -190,6 +190,10 @@ class WC_Customizer {
 
 					add_filter( 'woocommerce_get_availability_text', array( $this, 'customize_single_out_of_stock_text' ), 10, 2 );
 
+				} elseif ( 'single_backorder_text' === $filter_name ) {
+
+					add_filter( 'woocommerce_get_availability_text', array( $this, 'customize_single_backorder_text' ), 10, 2 );
+
 				} else {
 
 					add_filter( $filter_name, array( $this, 'customize' ), 50 );
@@ -365,6 +369,25 @@ class WC_Customizer {
 		// out of stock text
 		if ( isset( $this->filters['single_out_of_stock_text'] ) && ! $product->is_in_stock() ) {
 			return $this->filters['single_out_of_stock_text'];
+		}
+
+		return $text;
+	}
+
+
+	/**
+	 * Apply the product page backorder text customization
+	 *
+	 * @since 2.5.3
+	 * @param string $text backorder text
+	 * @param WC_Product $product product object
+	 * @return string modified backorder text
+	 */
+	public function customize_single_backorder_text( $text, $product ) {
+
+		// Backorder text
+		if ( isset( $this->filters['single_backorder_text'] ) && $product->managing_stock() && $product->is_on_backorder( 1 ) ) {
+			return $this->filters['single_backorder_text'];
 		}
 
 		return $text;

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -5,7 +5,7 @@
  * Description: Customize WooCommerce without code! Easily change add to cart button text and more.
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 2.5.3
+ * Version: 2.5.4
  * Text Domain: woocommerce-customizer
  * Domain Path: /i18n/languages/
  *
@@ -346,10 +346,15 @@ class WC_Customizer {
 			// grouped add to cart text
 			return $this->filters['grouped_add_to_cart_text'];
 
-		} elseif( isset( $this->filters['external_add_to_cart_text'] ) && $product->is_type( 'external' ) ) {
+		} elseif ( isset( $this->filters['external_add_to_cart_text'] ) && $product->is_type( 'external' ) ) {
 
 			// external add to cart text
 			return $this->filters['external_add_to_cart_text'];
+
+		} elseif ( isset( $this->filters['bundle_add_to_cart_text'] ) && $product->is_type( 'bundle' ) ) {
+
+			// bundle add to cart text
+			return $this->filters['bundle_add_to_cart_text'];
 		}
 
 		return $text;

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -20,7 +20,7 @@
  * @copyright Copyright (c) 2013-2018, SkyVerge, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
- * WC requires at least: 2.5.5
+ * WC requires at least: 2.6.14
  * WC tested up to: 3.4.3
  */
 
@@ -77,7 +77,7 @@ class WC_Customizer {
 	const VERSION = '2.6.0-dev.1';
 
 	/** required WooCommerce version number */
-	const MIN_WOOCOMMERCE_VERSION = '2.5.5';
+	const MIN_WOOCOMMERCE_VERSION = '2.6.14';
 
 	/** @var \WC_Customizer single instance of this plugin */
 	protected static $instance;

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -210,11 +210,11 @@ class WC_Customizer {
 
 				} elseif ( 'single_out_of_stock_text' === $filter_name ) {
 
-					add_filter( 'woocommerce_get_availability_text', array( $this, 'customize_single_out_of_stock_text' ), 10, 2 );
+					add_filter( 'woocommerce_get_availability_text', array( $this, 'customize_single_out_of_stock_text' ), 50, 2 );
 
 				} elseif ( 'single_backorder_text' === $filter_name ) {
 
-					add_filter( 'woocommerce_get_availability_text', array( $this, 'customize_single_backorder_text' ), 10, 2 );
+					add_filter( 'woocommerce_get_availability_text', array( $this, 'customize_single_backorder_text' ), 50, 2 );
 
 				} else {
 

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -5,7 +5,7 @@
  * Description: Customize WooCommerce without code! Easily change add to cart button text and more.
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 2.5.1
+ * Version: 2.5.2
  * Text Domain: woocommerce-customizer
  * Domain Path: /i18n/languages/
  *
@@ -186,6 +186,10 @@ class WC_Customizer {
 
 					add_filter( 'woocommerce_sale_flash', array( $this, 'customize_woocommerce_sale_flash' ), 50, 3 );
 
+				} elseif ( 'single_out_of_stock_text' === $filter_name ) {
+
+					add_filter( 'woocommerce_get_availability_text', array( $this, 'customize_single_out_of_stock_text' ), 10, 2 );
+
 				} else {
 
 					add_filter( $filter_name, array( $this, 'customize' ), 50 );
@@ -342,6 +346,25 @@ class WC_Customizer {
 
 			// external add to cart text
 			return $this->filters['external_add_to_cart_text'];
+		}
+
+		return $text;
+	}
+
+
+	/**
+	 * Apply the product page out of stock text customization
+	 *
+	 * @since 2.5.2
+	 * @param string $text out of stock text
+	 * @param WC_Product $product product object
+	 * @return string modified out of stock text
+	 */
+	public function customize_single_out_of_stock_text( $text, $product ) {
+
+		// out of stock text
+		if ( isset( $this->filters['single_out_of_stock_text'] ) && ! $product->is_in_stock() ) {
+			return $this->filters['single_out_of_stock_text'];
 		}
 
 		return $text;

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -5,11 +5,11 @@
  * Description: Customize WooCommerce without code! Easily change add to cart button text and more.
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 2.5.4
+ * Version: 2.6.0-dev.1
  * Text Domain: woocommerce-customizer
  * Domain Path: /i18n/languages/
  *
- * Copyright: (c) 2013-2017, SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2013-2018, SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -17,8 +17,11 @@
  * @package   WC-Customizer
  * @author    SkyVerge
  * @category  Utility
- * @copyright Copyright (c) 2013-2017, SkyVerge, Inc.
+ * @copyright Copyright (c) 2013-2018, SkyVerge, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ *
+ * WC requires at least: 2.5.5
+ * WC tested up to: 3.4.3
  */
 
 defined( 'ABSPATH' ) or exit;
@@ -71,7 +74,7 @@ class WC_Customizer {
 
 
 	/** plugin version number */
-	const VERSION = '2.5.1';
+	const VERSION = '2.6.0-dev.1';
 
 	/** @var \WC_Customizer single instance of this plugin */
 	protected static $instance;
@@ -364,9 +367,10 @@ class WC_Customizer {
 	/**
 	 * Apply the product page out of stock text customization
 	 *
-	 * @since 2.5.2
+	 * @since 2.6.0-dev.1
+	 *
 	 * @param string $text out of stock text
-	 * @param WC_Product $product product object
+	 * @param \WC_Product $product product object
 	 * @return string modified out of stock text
 	 */
 	public function customize_single_out_of_stock_text( $text, $product ) {
@@ -383,14 +387,15 @@ class WC_Customizer {
 	/**
 	 * Apply the product page backorder text customization
 	 *
-	 * @since 2.5.3
+	 * @since 2.6.0-dev.1
+	 *
 	 * @param string $text backorder text
-	 * @param WC_Product $product product object
+	 * @param \WC_Product $product product object
 	 * @return string modified backorder text
 	 */
 	public function customize_single_backorder_text( $text, $product ) {
 
-		// Backorder text
+		// backorder text
 		if ( isset( $this->filters['single_backorder_text'] ) && $product->managing_stock() && $product->is_on_backorder( 1 ) ) {
 			return $this->filters['single_backorder_text'];
 		}

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -82,6 +82,9 @@ class WC_Customizer {
 	/** @var \WC_Customizer single instance of this plugin */
 	protected static $instance;
 
+	/** @var \WC_Customizer_Integrations integrations class instance */
+	protected $integrations;
+
 	/** @var \WC_Customizer_Settings instance */
 	public $settings;
 
@@ -112,6 +115,8 @@ class WC_Customizer {
 			$this->install();
 		}
 
+		$this->includes();
+
 		add_action( 'woocommerce_init', array( $this, 'load_customizations' ) );
 	}
 
@@ -137,6 +142,17 @@ class WC_Customizer {
 
 		/* translators: Placeholders: %s - plugin name */
 		_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'You cannot unserialize instances of %s.', 'woocommerce-customizer' ), 'WooCommerce Customizer' ), '2.3.0' );
+	}
+
+
+	/**
+	 * Loads required filed.
+	 *
+	 * @since 2.6.0-dev.1
+	 */
+	protected function includes() {
+		require_once( 'includes/class-wc-customizer-integrations.php' );
+		$this->integrations = new WC_Customizer_Integrations();
 	}
 
 
@@ -395,10 +411,6 @@ class WC_Customizer {
 			// external add to cart text
 			return $this->filters['external_add_to_cart_text'];
 
-		} elseif ( isset( $this->filters['bundle_add_to_cart_text'] ) && $product->is_type( 'bundle' ) ) {
-
-			// bundle add to cart text
-			return $this->filters['bundle_add_to_cart_text'];
 		}
 
 		return $text;
@@ -589,6 +601,18 @@ class WC_Customizer {
 			self::$instance = new self();
 		}
 		return self::$instance;
+	}
+
+
+	/**
+	 * Gets the integrations class instance.
+	 *
+	 * @since 2.6.0-dev.1
+	 *
+	 * @return \WC_Customizer_Integrations
+	 */
+	public function get_integrations_instance() {
+		return $this->integrations;
 	}
 
 


### PR DESCRIPTION
Changes purposed in this pull request:

* Add option to change Out of stock text on single product page.

<img width="755" alt="screen shot 2561-05-11 at 1 17 44 pm" src="https://user-images.githubusercontent.com/3271452/39909653-e84d80e2-551d-11e8-9a09-5d29e59939ee.png">

* Add option to change Available on backorder text on single product page.

![screen shot 2561-05-17 at 10 46 35 am](https://user-images.githubusercontent.com/3271452/40155778-b7e66800-59bf-11e8-9e07-1889cb041f37.png)


Closes: #9 