### PR TITLE
Use media library to select placeholder image

### DIFF
--- a/assets/js/admin/wc-customizer-admin.js
+++ b/assets/js/admin/wc-customizer-admin.js
@@ -1,0 +1,31 @@
+jQuery( document ).ready( function( $ ) {
+    // Store the media library "select media" frame.
+    var select_frame;
+
+    jQuery('#media_library_button').click( function( event ){
+        event.preventDefault();
+
+        // Create the media library frame.
+        select_frame = wp.media.frames.select_frame = wp.media({
+            frame: 'select',
+            title: 'Select an image',
+            button: {
+                text: 'Use this image'
+            },
+            // We only want one image from the media library.
+            multiple: false
+        });
+
+        // When an image is selected, update the image preview.
+        select_frame.on( 'select', function() {
+            var image = select_frame.state().get('selection').first().toJSON();
+            $( '#media_preview' ).attr( 'src', image.url ).css( 'width', 'auto' );
+            // Store the selected image URL to be saved via the settings form.
+            $( '#woocommerce_placeholder_img_src' ).val( image.url );
+        });
+
+        // Open the media library model.
+        select_frame.open();
+    });
+
+});

--- a/assets/js/admin/wc-customizer-admin.js
+++ b/assets/js/admin/wc-customizer-admin.js
@@ -18,7 +18,7 @@ jQuery( document ).ready( function( $ ) {
 
         // When an image is selected, update the image preview.
         select_frame.on( 'select', function() {
-            var image = select_frame.state().get('selection').first().toJSON();
+            var image = select_frame.state().get( 'selection' ).first().toJSON();
             $( '#media_preview' ).attr( 'src', image.url ).css( 'width', 'auto' );
             // Store the selected image URL to be saved via the settings form.
             $( '#woocommerce_placeholder_img_src' ).val( image.url );

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -499,10 +499,10 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 				</th>
 				<td class="forminp forminp-text">
 					<div class="media-library-wrapper">
-						<img id="media_preview" src="<?php echo $placeholder_url; ?>" style="max-height: 200px;">
+						<img id="media_preview" src="<?php echo esc_url( $placeholder_url ); ?>" style="max-height: 200px;">
 					</div>
 					<input id="media_library_button" type="button" class="button" value="<?php _e( 'Choose image' ); ?>" />
-					<input type="hidden" name="woocommerce_placeholder_img_src" id="woocommerce_placeholder_img_src" value="<?php echo $placeholder_url; ?>">
+					<input type="hidden" name="woocommerce_placeholder_img_src" id="woocommerce_placeholder_img_src" value="<?php echo esc_url( $placeholder_url ); ?>">
 				</td>
 			</tr>
 			</tbody></table>

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -438,8 +438,6 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 
 					array(
 						'id'       => 'woocommerce_media_library',
-						'title'    => __( 'Placeholder Image source', 'woocommerce-customizer' ),
-						'desc_tip' => __( 'Change the default placeholder image by setting this to a valid image URL', 'woocommerce-customizer' ),
 						'type'     => 'woocommerce_customizer_media_library'
 					),
 

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -46,7 +46,7 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 
 		parent::__construct();
 
-		wp_enqueue_media();
+		wp_enqueue_media( array( 'serializejson', 'media-models', 'wp-util' ) );
 
 		// load custom admin scripts
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_scripts' ), 11 );

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -495,7 +495,7 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 		<table class="form-table">
 			<tbody><tr valign="top">
 				<th scope="row" class="titledesc">
-					<label for="woocommerce_placeholder_img_src"><?php _e( 'Placeholder Image' ); ?></label>
+					<label for="woocommerce_placeholder_img_src"><?php esc_html_e( 'Placeholder Image', 'woocommerce-customizer' ); ?></label>
 				</th>
 				<td class="forminp forminp-text">
 					<div class="media-library-wrapper">

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -150,7 +150,7 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 		 * included in the standard settings fields.
 		 * Retrieve it from the POST here.
 		 */
-		$woocommerce_placeholder_img_src = filter_input( INPUT_POST, 'woocommerce_placeholder_img_src', FILTER_SANITIZE_STRING );
+		$woocommerce_placeholder_img_src = isset( $_POST['woocommerce_placeholder_img_src'] ) ? wc_clean( $_POST['woocommerce_placeholder_img_src'] ) : '';
 
 		$this->customizations['woocommerce_placeholder_img_src'] = $woocommerce_placeholder_img_src;
 

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -426,7 +426,7 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 						'id'       => 'woocommerce_placeholder_img_src',
 						'title'    => __( 'Placeholder Image source', 'woocommerce-customizer' ),
 						'desc_tip' => __( 'Change the default placeholder image by setting this to a valid image URL', 'woocommerce-customizer' ),
-						'type'     => 'text'
+						'type'     => 'woocommerce_customizer_media_library'
 					),
 
 					array( 'type' => 'sectionend' ),

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -140,6 +140,13 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 			}
 		}
 
+		// The placeholder image URL is set via the media library, so isn't
+		// included in the standard settings fields.
+		// Retrieve it from the POST here.
+		$woocommerce_placeholder_img_src = filter_input( INPUT_POST, 'woocommerce_placeholder_img_src', FILTER_SANITIZE_STRING );
+
+		$this->customizations[ 'woocommerce_placeholder_img_src' ] = $woocommerce_placeholder_img_src;
+
 		update_option( 'wc_customizer_active_customizations', $this->customizations );
 	}
 

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -65,7 +65,7 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 	 */
 	public function load_scripts() {
 
-		wp_enqueue_script( 'woocommerce-customizer', plugins_url( '../assets/js/admin/wc-customizer-admin.js', __FILE__) );
+		wp_enqueue_script( 'woocommerce-customizer', plugins_url( '../assets/js/admin/wc-customizer-admin.js', __FILE__), array(), WC_Customizer::VERSION );
 	}
 
 

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -46,7 +46,21 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 
 		parent::__construct();
 
+		wp_enqueue_media();
+
+		// load custom admin scripts
+		add_action( 'admin_enqueue_scripts', array( $this, 'load_scripts' ), 11 );
+
 		$this->customizations = get_option( 'wc_customizer_active_customizations', array() );
+	}
+
+
+	/**
+	 *
+	 */
+	public function load_scripts() {
+
+		wp_enqueue_script( 'woocommerce-customizer', plugins_url('../assets/js/admin/wc-customizer-admin.js', __FILE__) );
 	}
 
 
@@ -423,7 +437,7 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 					),
 
 					array(
-						'id'       => 'woocommerce_placeholder_img_src',
+						'id'       => 'woocommerce_media_library',
 						'title'    => __( 'Placeholder Image source', 'woocommerce-customizer' ),
 						'desc_tip' => __( 'Change the default placeholder image by setting this to a valid image URL', 'woocommerce-customizer' ),
 						'type'     => 'woocommerce_customizer_media_library'

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -48,7 +48,7 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 
 		wp_enqueue_media();
 
-		// load custom admin scripts
+		// Load custom admin scripts.
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_scripts' ), 11 );
 
 		$this->customizations = get_option( 'wc_customizer_active_customizations', array() );
@@ -142,9 +142,11 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 			}
 		}
 
-		// The placeholder image URL is set via the media library, so isn't
-		// included in the standard settings fields.
-		// Retrieve it from the POST here.
+		/*
+		 * The placeholder image URL is set via the media library, so isn't
+		 * included in the standard settings fields.
+		 * Retrieve it from the POST here.
+		 */
 		$woocommerce_placeholder_img_src = filter_input( INPUT_POST, 'woocommerce_placeholder_img_src', FILTER_SANITIZE_STRING );
 
 		$this->customizations[ 'woocommerce_placeholder_img_src' ] = $woocommerce_placeholder_img_src;

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -501,7 +501,7 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 					<div class="media-library-wrapper">
 						<img id="media_preview" src="<?php echo esc_url( $placeholder_url ); ?>" style="max-height: 200px;">
 					</div>
-					<input id="media_library_button" type="button" class="button" value="<?php _e( 'Choose image' ); ?>" />
+					<input id="media_library_button" type="button" class="button" value="<?php esc_attr_e( 'Choose image', 'woocommerce-customizer' ); ?>" />
 					<input type="hidden" name="woocommerce_placeholder_img_src" id="woocommerce_placeholder_img_src" value="<?php echo esc_url( $placeholder_url ); ?>">
 				</td>
 			</tr>

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -56,11 +56,13 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 
 
 	/**
+	 * Loads custom scripts used by the settings page
 	 *
+	 * @since 2.6.1
 	 */
 	public function load_scripts() {
 
-		wp_enqueue_script( 'woocommerce-customizer', plugins_url('../assets/js/admin/wc-customizer-admin.js', __FILE__) );
+		wp_enqueue_script( 'woocommerce-customizer', plugins_url( '../assets/js/admin/wc-customizer-admin.js', __FILE__) );
 	}
 
 

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -51,6 +51,9 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 		// load custom admin scripts
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_scripts' ), 11 );
 
+		// add action to render custom media library button field
+		add_action( 'woocommerce_admin_field_woocommerce_customizer_media_library', array( $this, 'render_media_library_field' ) );
+
 		$this->customizations = get_option( 'wc_customizer_active_customizations', array() );
 	}
 
@@ -469,6 +472,41 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 		$current_section = isset( $GLOBALS['current_section'] ) ? $GLOBALS['current_section'] : 'shop_loop';
 
 		return isset( $settings[ $current_section ] ) ?  $settings[ $current_section ] : $settings['shop_loop'];
+	}
+
+
+	/**
+	 * Renders a button which opens the media library model
+	 *
+	 * Also renders an image field to display the currently selected image
+	 * and a hidden field used to store the selected image URL
+	 *
+	 * @since 2.6.1
+	 */
+	public function render_media_library_field() {
+
+		/*
+		 * Get the placeholder image URL directly from settings so the admin form
+		 * shows the correct image immediately after saving.
+		 */
+		$placeholder_url = $this->customizations['woocommerce_placeholder_img_src'];
+
+		?>
+		<table class="form-table">
+			<tbody><tr valign="top">
+				<th scope="row" class="titledesc">
+					<label for="woocommerce_placeholder_img_src"><?php _e( 'Placeholder Image' ); ?></label>
+				</th>
+				<td class="forminp forminp-text">
+					<div class="media-library-wrapper">
+						<img id="media_preview" src="<?php echo $placeholder_url; ?>" style="max-height: 200px;">
+					</div>
+					<input id="media_library_button" type="button" class="button" value="<?php _e( 'Choose image' ); ?>" />
+					<input type="hidden" name="woocommerce_placeholder_img_src" id="woocommerce_placeholder_img_src" value="<?php echo $placeholder_url; ?>">
+				</td>
+			</tr>
+			</tbody></table>
+		<?php
 	}
 
 

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -48,7 +48,7 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 
 		wp_enqueue_media();
 
-		// Load custom admin scripts.
+		// load custom admin scripts
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_scripts' ), 11 );
 
 		$this->customizations = get_option( 'wc_customizer_active_customizations', array() );
@@ -149,7 +149,7 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 		 */
 		$woocommerce_placeholder_img_src = filter_input( INPUT_POST, 'woocommerce_placeholder_img_src', FILTER_SANITIZE_STRING );
 
-		$this->customizations[ 'woocommerce_placeholder_img_src' ] = $woocommerce_placeholder_img_src;
+		$this->customizations['woocommerce_placeholder_img_src'] = $woocommerce_placeholder_img_src;
 
 		update_option( 'wc_customizer_active_customizations', $this->customizations );
 	}

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -177,6 +177,14 @@ class WC_Customizer {
 	 */
 	public function render_media_library_field() {
 
+		?><div class="media-library-wrapper">
+			<img id="media_preview" src="" style="max-height: 100px;">
+		</div>
+		<input id="media_library_button" type="button" class="button" value="<?php _e( 'Choose image' ); ?>" />
+		<input type="hidden" id="woocommerce_placeholder_img_src" value="">
+
+		<?php
+
 	}
 
 

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -38,7 +38,6 @@ if ( version_compare( get_option( 'woocommerce_db_version' ), WC_Customizer::MIN
 	return;
 }
 
-
 /**
  * # WooCommerce Customizer Main Plugin Class
  *
@@ -118,6 +117,9 @@ class WC_Customizer {
 		$this->includes();
 
 		add_action( 'woocommerce_init', array( $this, 'load_customizations' ) );
+
+		add_action( 'woocommerce_admin_field_woocommerce_customizer_media_library', array( $this, 'render_media_library_field' ) );
+
 	}
 
 
@@ -167,6 +169,14 @@ class WC_Customizer {
 
 		$settings[] = require_once( 'includes/class-wc-customizer-settings.php' );
 		return $settings;
+	}
+
+
+	/**
+	 * TODO: Render media library field here.
+	 */
+	public function render_media_library_field() {
+
 	}
 
 

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -174,17 +174,26 @@ class WC_Customizer {
 
 	/**
 	 * TODO: Render media library field here.
+	 * TODO: Get previously selected image URL.
 	 */
 	public function render_media_library_field() {
 
-		?><div class="media-library-wrapper">
-			<img id="media_preview" src="" style="max-height: 100px;">
-		</div>
-		<input id="media_library_button" type="button" class="button" value="<?php _e( 'Choose image' ); ?>" />
-		<input type="hidden" id="woocommerce_placeholder_img_src" value="">
-
+		?>
+		<table class="form-table">
+			<tbody><tr valign="top">
+				<th scope="row" class="titledesc">
+					<label for="woocommerce_placeholder_img_src"><?php _e( 'Placeholder Image' ); ?></label>
+				</th>
+				<td class="forminp forminp-text">
+					<div class="media-library-wrapper">
+						<img id="media_preview" src="" style="max-height: 100px;">
+					</div>
+					<input id="media_library_button" type="button" class="button" value="<?php _e( 'Choose image' ); ?>" />
+					<input type="hidden" name="woocommerce_placeholder_img_src" id="woocommerce_placeholder_img_src" value="">
+				</td>
+			</tr>
+			</tbody></table>
 		<?php
-
 	}
 
 

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -174,9 +174,13 @@ class WC_Customizer {
 
 	/**
 	 * TODO: Render media library field here.
-	 * TODO: Get previously selected image URL.
 	 */
 	public function render_media_library_field() {
+
+		// Get previously chosen placeholder image URL.
+		add_filter( 'woocommerce_placeholder_img_src', array( $this, 'customize' ) );
+
+		$placeholder_url = wc_placeholder_img_src();
 
 		?>
 		<table class="form-table">
@@ -186,10 +190,10 @@ class WC_Customizer {
 				</th>
 				<td class="forminp forminp-text">
 					<div class="media-library-wrapper">
-						<img id="media_preview" src="" style="max-height: 100px;">
+						<img id="media_preview" src="<?php echo $placeholder_url; ?>" style="max-height: 100px;">
 					</div>
 					<input id="media_library_button" type="button" class="button" value="<?php _e( 'Choose image' ); ?>" />
-					<input type="hidden" name="woocommerce_placeholder_img_src" id="woocommerce_placeholder_img_src" value="">
+					<input type="hidden" name="woocommerce_placeholder_img_src" id="woocommerce_placeholder_img_src" value="<?php echo $placeholder_url; ?>">
 				</td>
 			</tr>
 			</tbody></table>

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -347,8 +347,10 @@ class WC_Customizer {
 	 */
 	public function render_media_library_field() {
 
-		// Get the placeholder image URL directly from settings so the admin form
-		// shows the correct image immediately after saving.
+		/*
+		 * Get the placeholder image URL directly from settings so the admin form
+		 * shows the correct image immediately after saving.
+		 */
 		$placeholder_url = $this->settings->customizations["woocommerce_placeholder_img_src"];
 
 		?>

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -119,8 +119,8 @@ class WC_Customizer {
 
 		add_action( 'woocommerce_init', array( $this, 'load_customizations' ) );
 
+		// Add action to render custom media library button field.
 		add_action( 'woocommerce_admin_field_woocommerce_customizer_media_library', array( $this, 'render_media_library_field' ) );
-
 	}
 
 
@@ -348,7 +348,7 @@ class WC_Customizer {
 	public function render_media_library_field() {
 
 		// Get the placeholder image URL directly from settings so the admin form
-		// shows the correct immediately after saving.
+		// shows the correct image immediately after saving.
 		$placeholder_url = $this->settings->customizations["woocommerce_placeholder_img_src"];
 
 		?>

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -173,35 +173,6 @@ class WC_Customizer {
 
 
 	/**
-	 * TODO: Render media library field here.
-	 */
-	public function render_media_library_field() {
-
-		// Get previously chosen placeholder image URL.
-		add_filter( 'woocommerce_placeholder_img_src', array( $this, 'customize' ) );
-
-		$placeholder_url = wc_placeholder_img_src();
-
-		?>
-		<table class="form-table">
-			<tbody><tr valign="top">
-				<th scope="row" class="titledesc">
-					<label for="woocommerce_placeholder_img_src"><?php _e( 'Placeholder Image' ); ?></label>
-				</th>
-				<td class="forminp forminp-text">
-					<div class="media-library-wrapper">
-						<img id="media_preview" src="<?php echo $placeholder_url; ?>" style="max-height: 100px;">
-					</div>
-					<input id="media_library_button" type="button" class="button" value="<?php _e( 'Choose image' ); ?>" />
-					<input type="hidden" name="woocommerce_placeholder_img_src" id="woocommerce_placeholder_img_src" value="<?php echo $placeholder_url; ?>">
-				</td>
-			</tr>
-			</tbody></table>
-		<?php
-	}
-
-
-	/**
 	 * Load customizations after WC is loaded so the version can be checked
 	 *
 	 * @since 1.2.0
@@ -362,6 +333,39 @@ class WC_Customizer {
 		);
 
 		printf( '<div class="error"><p>%s</p></div>', $message );
+	}
+
+
+	/**
+	 * Renders a button which opens the media library model
+	 *
+	 * Also renders an image field to display the currently selected image
+	 * and a hidden field used to store the selected image URL
+	 *
+	 * @since 2.6.1
+	 */
+	public function render_media_library_field() {
+
+		// Get the placeholder image URL directly from settings so the admin form
+		// shows the correct immediately after saving.
+		$placeholder_url = $this->settings->customizations["woocommerce_placeholder_img_src"];
+
+		?>
+		<table class="form-table">
+			<tbody><tr valign="top">
+				<th scope="row" class="titledesc">
+					<label for="woocommerce_placeholder_img_src"><?php _e( 'Placeholder Image' ); ?></label>
+				</th>
+				<td class="forminp forminp-text">
+					<div class="media-library-wrapper">
+						<img id="media_preview" src="<?php echo $placeholder_url; ?>" style="max-height: 200px;">
+					</div>
+					<input id="media_library_button" type="button" class="button" value="<?php _e( 'Choose image' ); ?>" />
+					<input type="hidden" name="woocommerce_placeholder_img_src" id="woocommerce_placeholder_img_src" value="<?php echo $placeholder_url; ?>">
+				</td>
+			</tr>
+			</tbody></table>
+		<?php
 	}
 
 

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -118,9 +118,6 @@ class WC_Customizer {
 		$this->includes();
 
 		add_action( 'woocommerce_init', array( $this, 'load_customizations' ) );
-
-		// add action to render custom media library button field
-		add_action( 'woocommerce_admin_field_woocommerce_customizer_media_library', array( $this, 'render_media_library_field' ) );
 	}
 
 
@@ -334,41 +331,6 @@ class WC_Customizer {
 		);
 
 		printf( '<div class="error"><p>%s</p></div>', $message );
-	}
-
-
-	/**
-	 * Renders a button which opens the media library model
-	 *
-	 * Also renders an image field to display the currently selected image
-	 * and a hidden field used to store the selected image URL
-	 *
-	 * @since 2.6.1
-	 */
-	public function render_media_library_field() {
-
-		/*
-		 * Get the placeholder image URL directly from settings so the admin form
-		 * shows the correct image immediately after saving.
-		 */
-		$placeholder_url = $this->settings->customizations['woocommerce_placeholder_img_src'];
-
-		?>
-		<table class="form-table">
-			<tbody><tr valign="top">
-				<th scope="row" class="titledesc">
-					<label for="woocommerce_placeholder_img_src"><?php _e( 'Placeholder Image' ); ?></label>
-				</th>
-				<td class="forminp forminp-text">
-					<div class="media-library-wrapper">
-						<img id="media_preview" src="<?php echo $placeholder_url; ?>" style="max-height: 200px;">
-					</div>
-					<input id="media_library_button" type="button" class="button" value="<?php _e( 'Choose image' ); ?>" />
-					<input type="hidden" name="woocommerce_placeholder_img_src" id="woocommerce_placeholder_img_src" value="<?php echo $placeholder_url; ?>">
-				</td>
-			</tr>
-			</tbody></table>
-		<?php
 	}
 
 

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -38,6 +38,7 @@ if ( version_compare( get_option( 'woocommerce_db_version' ), WC_Customizer::MIN
 	return;
 }
 
+
 /**
  * # WooCommerce Customizer Main Plugin Class
  *

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -119,7 +119,7 @@ class WC_Customizer {
 
 		add_action( 'woocommerce_init', array( $this, 'load_customizations' ) );
 
-		// Add action to render custom media library button field.
+		// add action to render custom media library button field
 		add_action( 'woocommerce_admin_field_woocommerce_customizer_media_library', array( $this, 'render_media_library_field' ) );
 	}
 
@@ -351,7 +351,7 @@ class WC_Customizer {
 		 * Get the placeholder image URL directly from settings so the admin form
 		 * shows the correct image immediately after saving.
 		 */
-		$placeholder_url = $this->settings->customizations["woocommerce_placeholder_img_src"];
+		$placeholder_url = $this->settings->customizations['woocommerce_placeholder_img_src'];
 
 		?>
 		<table class="form-table">


### PR DESCRIPTION
This pull request introduces a media library button / preview image to the Customizer / Misc settings tab.

<img width="838" alt="screen shot 2018-09-01 at 2 41 20 pm" src="https://user-images.githubusercontent.com/87952/44950204-c4cb0680-adf6-11e8-934a-c10da441b8d2.png">

<img width="1421" alt="screen shot 2018-09-01 at 2 41 36 pm" src="https://user-images.githubusercontent.com/87952/44950208-c98fba80-adf6-11e8-8694-2d2dbe414cde.png">

<img width="712" alt="screen shot 2018-09-01 at 2 41 59 pm" src="https://user-images.githubusercontent.com/87952/44950211-ceed0500-adf6-11e8-982b-9de48fe5a51b.png">
