### PR TITLE
Customizer: WC 3.9 Compatibility Release

### DIFF
--- a/includes/class-wc-customizer-integrations.php
+++ b/includes/class-wc-customizer-integrations.php
@@ -17,7 +17,7 @@
  * needs please refer to http://www.skyverge.com/product/woocommerce-customizer/ for more information.
  *
  * @author      SkyVerge
- * @copyright   Copyright (c) 2013-2019, SkyVerge, Inc.
+ * @copyright   Copyright (c) 2013-2020, SkyVerge, Inc. (info@skyverge.com)
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 

--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -17,7 +17,7 @@
  * needs please refer to http://www.skyverge.com/product/woocommerce-customizer/ for more information.
  *
  * @author      SkyVerge
- * @copyright   Copyright (c) 2013-2019, SkyVerge, Inc.
+ * @copyright   Copyright (c) 2013-2020, SkyVerge, Inc. (info@skyverge.com)
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@s
 Tags: woocommerce, woocommerce shop, woocommerce filters, woocommerce text
 Requires at least: 4.4
 Tested up to: 5.2.4
-Stable tag: 2.7.1
+Stable tag: 2.7.2-dev.1
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,9 @@ Of course! Please fork the [GitHub](https://github.com/skyverge/woocommerce-cust
 
 == Changelog ==
 
+= 2020.nn.nn - version 2.7.2-dev.1 =
+* Misc - Add support for WooCommerce 3.9
+
 = 2019.11.11 - version 2.7.1 =
 * Misc - Add support for WooCommerce 3.8
 

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -9,13 +9,13 @@
  * Text Domain: woocommerce-customizer
  * Domain Path: /i18n/languages/
  *
- * Copyright: (c) 2013-2019, SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2013-2020, SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  *
  * @author    SkyVerge
- * @copyright Copyright (c) 2013-2019, SkyVerge, Inc.
+ * @copyright Copyright (c) 2013-2020, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -5,7 +5,7 @@
  * Description: Customize WooCommerce without code! Easily change add to cart button text and more.
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 2.7.1
+ * Version: 2.7.2-dev.1
  * Text Domain: woocommerce-customizer
  * Domain Path: /i18n/languages/
  *
@@ -46,7 +46,7 @@ class WC_Customizer {
 
 
 	/** plugin version number */
-	const VERSION = '2.7.1';
+	const VERSION = '2.7.2-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';


### PR DESCRIPTION
# Summary

This PR adds support for WooCommerce 3.9 and updates the copyright year to 2020.

### Stories

- [CH 24716](https://app.clubhouse.io/skyverge/story/24716/woocommerce-3-9-compatibility)

## Details

There were no incompatibilities with WC 3.9.

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
