### PR TITLE
Bumps version number to 2.7.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: SkyVerge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+Customizer
 Tags: woocommerce, woocommerce shop, woocommerce filters, woocommerce text
 Requires at least: 4.4
-Tested up to: 5.4.1
-Stable tag: 2.7.4
+Tested up to: 5.9.1
+Stable tag: 2.7.5
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -70,6 +70,9 @@ Of course! Please fork the [GitHub](https://github.com/skyverge/woocommerce-cust
 1. Settings Page to start customizing!
 
 == Changelog ==
+
+= 2022.02.25 - version 2.7.5 =
+* Misc - Tests Compatibility with WordPress 5.9.1
 
 = 2020.05.04 - version 2.7.4 =
 * Misc - Add support for WooCommerce 4.1

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -5,7 +5,7 @@
  * Description: Customize WooCommerce without code! Easily change add to cart button text and more.
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 2.7.4
+ * Version: 2.7.5
  * Text Domain: woocommerce-customizer
  * Domain Path: /i18n/languages/
  *
@@ -46,7 +46,7 @@ class WC_Customizer {
 
 
 	/** plugin version number */
-	const VERSION = '2.7.4';
+	const VERSION = '2.7.5';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';


### PR DESCRIPTION
# Summary <!-- Required -->
Tests and bumps version number to 2.7.5 and compatible with WordPress 5.9.1

### Issue: [MWC-4384](https://jira.godaddy.com/browse/MWC-4384)

## QA <!-- Optional -->
- [ ] Would like to confirm that this is all that's needed for WordPress plugin repo?

## Before merge <!-- Required -->

- [x] This PR makes the appropriate modifications to automated tests or explains why none are needed
- [x] This PR makes the appropriate modifications to documentation or explains why none are needed
- [x] This change does not impact usage or expected outputs of covered code
