### PR TITLE
Changes filter for tax label

### DIFF
--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -394,7 +394,7 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 					),
 
 					array(
-						'id'       => 'woocommerce_countries_tax_or_vat',
+						'id'       => 'woocommerce_rate_label',
 						'title'    => __( 'Tax Label', 'woocommerce-customizer' ),
 						'desc_tip' => __( 'Changes the Taxes label. Defaults to Tax for USA, VAT for European countries', 'woocommerce-customizer' ),
 						'type'     => 'text'


### PR DESCRIPTION
# Summary <!-- Required -->
This changes the filter from `woocommerce_countries_tax_or_vat`  to `woocommerce_rate_label` as it's used more to render a tax label.

### Issue: [MWC-4558](https://jira.godaddy.com/browse/MWC-4558)

## Details <!-- Optional -->
Currently the settings in our customizer plugin only change the tax label if the tax settings for "Display Tax Totals" in WC are set to "As Single Total". This update will update the tax label regardless of the setting.

You can see how this filter gets skipped [in this block of code](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/templates/cart/cart-totals.php#L75-L91) based on the settings mentioned above.

## QA <!-- Optional -->
- [ ] I've checked for other instances of this function, but this change doesn't appear to have any unintended effects. But curious on others takes as well.

## Before merge <!-- Required -->
- [x] This PR makes the appropriate modifications to documentation or explains why none are needed
- [x] This change does not impact usage or expected outputs of covered code
