### PR TITLE
Removes condition from backorder item

### DIFF
--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -405,7 +405,7 @@ class WC_Customizer {
 	public function customize_single_backorder_text( $text, $product ) {
 
 		// backorder text
-		if ( isset( $this->filters['single_backorder_text'] ) && $product->managing_stock() && $product->is_on_backorder( 1 ) ) {
+		if ( isset( $this->filters['single_backorder_text'] ) && $product->is_on_backorder( 1 ) ) {
 			return $this->filters['single_backorder_text'];
 		}
 


### PR DESCRIPTION
# Summary <!-- Required -->
This removes a condition that prevents backordered items from displaying the saved settings. .

### Issue: [MWC-4557](https://jira.godaddy.com/browse/MWC-4557)

## Details <!-- Optional -->
This condition was checking to see if "Maintaining Stock" was checked on the product. This appears to put too much constraint on when to swap out the text as a product and be put on backorder without the maintained stock setting being checked. 

Now it only checks is the customizer setting is checked and if their product is backordered.

## QA <!-- Optional -->
- [ ] I'm not seeing unintended changes on the fronted, would like to confirm that with whoever is reviewing this PR.

## Before merge <!-- Required -->
- [x] This PR makes the appropriate modifications to documentation or explains why none are needed
- [x] This change does not impact usage or expected outputs of covered code
