### PR TITLE
Removes image placeholder setting

### DIFF
--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -416,20 +416,6 @@ class WC_Customizer_Settings extends WC_Settings_Page {
 
 					array( 'type' => 'sectionend' ),
 
-					array(
-						'title' => __( 'Images', 'woocommerce-customizer' ),
-						'type'  => 'title'
-					),
-
-					array(
-						'id'       => 'woocommerce_placeholder_img_src',
-						'title'    => __( 'Placeholder Image source', 'woocommerce-customizer' ),
-						'desc_tip' => __( 'Change the default placeholder image by setting this to a valid image URL', 'woocommerce-customizer' ),
-						'type'     => 'text'
-					),
-
-					array( 'type' => 'sectionend' ),
-
 				),
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@s
 Tags: woocommerce, woocommerce shop, woocommerce filters, woocommerce text
 Requires at least: 4.7
 Tested up to: 5.9.1
-Stable tag: 2.7.6
+Stable tag: 2.7.6-dev.1
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -71,8 +71,8 @@ Of course! Please fork the [GitHub](https://github.com/skyverge/woocommerce-cust
 
 == Changelog ==
 
-= 2022.03.01 - version 2.7.6 =
-* Fix - Remove image placeholder. This is included in WC 3.5+
+= 2022.nn.nn - version 2.7.6-dev.1 =
+* Fix - Remove image placeholder (this is included in WC 3.5+)
 
 = 2022.03.01 - version 2.7.5 =
 * Misc - Require WooCommerce 3.9.4 or newer

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@s
 Tags: woocommerce, woocommerce shop, woocommerce filters, woocommerce text
 Requires at least: 4.7
 Tested up to: 5.9.1
-Stable tag: 2.7.5
+Stable tag: 2.7.6
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -70,6 +70,9 @@ Of course! Please fork the [GitHub](https://github.com/skyverge/woocommerce-cust
 1. Settings Page to start customizing!
 
 == Changelog ==
+
+= 2022.03.01 - version 2.7.6 =
+* Fix - Remove image placeholder. This is included in WC 3.5+
 
 = 2022.03.01 - version 2.7.5 =
 * Misc - Require WooCommerce 3.9.4 or newer

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -46,7 +46,7 @@ class WC_Customizer {
 
 
 	/** plugin version number */
-	const VERSION = '2.7.6';
+	const VERSION = '2.7.6-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.9.4';

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -5,7 +5,7 @@
  * Description: Customize WooCommerce without code! Easily change add to cart button text and more.
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 2.7.6
+ * Version: 2.7.6-dev.1
  * Text Domain: woocommerce-customizer
  * Domain Path: /i18n/languages/
  *

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -5,7 +5,7 @@
  * Description: Customize WooCommerce without code! Easily change add to cart button text and more.
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 2.7.5
+ * Version: 2.7.6
  * Text Domain: woocommerce-customizer
  * Domain Path: /i18n/languages/
  *
@@ -46,7 +46,7 @@ class WC_Customizer {
 
 
 	/** plugin version number */
-	const VERSION = '2.7.5';
+	const VERSION = '2.7.6';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.9.4';
@@ -167,13 +167,6 @@ class WC_Customizer {
 					} else {
 
 						add_filter( 'woocommerce_product_add_to_cart_text', array( $this, 'customize_add_to_cart_text' ), 50, 2 );
-					}
-
-				} elseif ( 'woocommerce_placeholder_img_src' === $filter_name ) {
-
-					// only filter placeholder images on the frontend
-					if ( ! is_admin() ) {
-						add_filter( $filter_name, array( $this, 'customize' ), 50 );
 					}
 
 				} elseif ( 'loop_sale_flash_text' === $filter_name || 'single_sale_flash_text' === $filter_name ) {


### PR DESCRIPTION
# Summary <!-- Required -->
Removes setting for changing the default image placeholder for products as this option was added to WooCommerce core in version 3.5. With the bump of our support to WooCommerce 3.9.4+ this setting is no longer needed. 

### Issue: [MWC-4559](https://jira.godaddy.com/browse/MWC-4559)

## Before merge <!-- Required -->
- [x] This PR makes the appropriate modifications to documentation or explains why none are needed
- [x] This change does not impact usage or expected outputs of covered code
